### PR TITLE
PostScript font name space replacement

### DIFF
--- a/Figma/AEUX/src/aeux.js
+++ b/Figma/AEUX/src/aeux.js
@@ -245,7 +245,7 @@ function getText(layer, parentFrame) {
         stroke: getStrokes(layer),
         blendMode: getLayerBlending(layer.blendMode),
         // fontName: layer.style.fontPostScriptName,
-        fontName: layer.fontName.family.replace(' ', '') + '-' + layer.fontName.style.replace(' ', ''),
+        fontName: layer.fontName.family.replaceAll(' ', '') + '-' + layer.fontName.style.replaceAll(' ', ''),
         fontSize: layer.fontSize,
         // trackingAdjusted: layer.style.letterSpacing / layer.style.fontSize * 1000,
         trackingAdjusted: getTracking(layer),


### PR DESCRIPTION
This changes the font name string transformation from .replace() to .replaceAll() . The original code will only replace the *first* space and leave the rest unchanged, causing significant amount of missing font issues.

Fixing Figma code. Have not checked Sketch.