### PR TITLE
 AlgoliaSearchBox.vueDOM text reinterpreted as HTML

### DIFF
--- a/Documentation/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/Documentation/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -68,7 +68,7 @@ export default {
     },
 
     update (options, lang) {
-      this.$el.innerHTML = '<input id="algolia-search-input" class="search-query">'
+      this.$el.innerText = '<input id="algolia-search-input" class="search-query">'
       this.initialize(options, lang)
     }
   }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.