### PR TITLE
 CSInterface.js DOM text reinterpreted as HTML

### DIFF
--- a/Ae/AEUX/public/CSInterface.js
+++ b/Ae/AEUX/public/CSInterface.js
@@ -687,7 +687,7 @@ CSInterface.prototype.initResourceBundle = function()
                    var resValue = resourceBundle[key];
                    if (key.length == resKey.length)
                    {
-                        resEl.innerHTML = resValue;
+                        resEl.innerText = resValue;
                    }
                    else if ('.' == key.charAt(resKey.length))
                    {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.